### PR TITLE
makes conftest useable for windows devs , fixes #714 (#715)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -101,6 +101,7 @@ class mscolab_settings(object):
     import logging
     import fs
     import secrets
+    from werkzeug.urls import url_join
 
     ROOT_DIR = '{constants.ROOT_DIR}'
     # directory where mss output files are stored
@@ -108,17 +109,17 @@ class mscolab_settings(object):
     if not root_fs.exists('colabTestData'):
         root_fs.makedir('colabTestData')
     BASE_DIR = ROOT_DIR
-    DATA_DIR = os.path.join(ROOT_DIR, 'colabTestData')
+    DATA_DIR = fs.path.join(ROOT_DIR, 'colabTestData')
     # mscolab data directory
-    MSCOLAB_DATA_DIR = os.path.join(DATA_DIR, 'filedata')
+    MSCOLAB_DATA_DIR = fs.path.join(DATA_DIR, 'filedata')
 
     # used to generate and parse tokens
     SECRET_KEY = secrets.token_urlsafe(16)
 
-    SQLALCHEMY_DB_URI = 'sqlite:///' + os.path.join(DATA_DIR, 'mscolab.db')
+    SQLALCHEMY_DB_URI = 'sqlite:///' + url_join(DATA_DIR, 'mscolab.db')
 
     # mscolab file upload settings
-    UPLOAD_FOLDER = os.path.join(DATA_DIR, 'uploads')
+    UPLOAD_FOLDER = fs.path.join(DATA_DIR, 'uploads')
     MAX_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MB
 
     # text to be written in new mscolab based ftml files.
@@ -139,10 +140,11 @@ class mscolab_settings(object):
     ROOT_FS = fs.open_fs(constants.ROOT_DIR)
     if not ROOT_FS.exists('mscolab'):
         ROOT_FS.makedir('mscolab')
-    with fs.open_fs(os.path.join(constants.ROOT_DIR, "mscolab")) as mscolab_fs:
-        mscolab_fs.writetext('mscolab_settings.py', config_string)
-    path = os.path.join(constants.ROOT_DIR, 'mscolab', 'mscolab_settings.py')
-    parent_path = os.path.join(constants.ROOT_DIR, 'mscolab')
+    with fs.open_fs(fs.path.join(constants.ROOT_DIR, "mscolab")) as mscolab_fs:
+        # windows needs \\ or / but mixed is terrible. *nix needs /
+        mscolab_fs.writetext('mscolab_settings.py', config_string.replace('\\', '/'))
+    path = fs.path.join(constants.ROOT_DIR, 'mscolab', 'mscolab_settings.py')
+    parent_path = fs.path.join(constants.ROOT_DIR, 'mscolab')
 
 
 imp.load_source('mss_wms_settings', constants.SERVER_CONFIG_FILE_PATH)

--- a/mslib/_tests/constants.py
+++ b/mslib/_tests/constants.py
@@ -41,19 +41,19 @@ CACHED_CONFIG_FILE = None
 SERVER_CONFIG_FILE = "mss_wms_settings.py"
 MSCOLAB_CONFIG_FILE = "mscolab_settings.py"
 ROOT_FS = TempFS(identifier="mss{}".format(SHA))
-ROOT_DIR = ROOT_FS.root_path
+ROOT_DIR = ROOT_FS.getsyspath("")
 
 if not ROOT_FS.exists("mss/testdata"):
     ROOT_FS.makedirs("mss/testdata")
-SERVER_CONFIG_FS = fs.open_fs(os.path.join(ROOT_DIR, "mss"))
-DATA_FS = fs.open_fs(os.path.join(ROOT_DIR, "mss/testdata"))
+SERVER_CONFIG_FS = fs.open_fs(fs.path.join(ROOT_DIR, "mss"))
+DATA_FS = fs.open_fs(fs.path.join(ROOT_DIR, "mss/testdata"))
 
-MSS_CONFIG_PATH = SERVER_CONFIG_FS.root_path
+MSS_CONFIG_PATH = SERVER_CONFIG_FS.getsyspath("")
 os.environ["MSS_CONFIG_PATH"] = MSS_CONFIG_PATH
-SERVER_CONFIG_FILE_PATH = os.path.join(SERVER_CONFIG_FS.root_path, SERVER_CONFIG_FILE)
+SERVER_CONFIG_FILE_PATH = fs.path.join(SERVER_CONFIG_FS.getsyspath(""), SERVER_CONFIG_FILE)
 
 # we keep DATA_DIR until we move netCDF4 files to pyfilesystem2
-DATA_DIR = DATA_FS.root_path
+DATA_DIR = DATA_FS.getsyspath("")
 
 # deployed mscolab url
 MSCOLAB_URL = "http://localhost:8083"

--- a/mslib/_tests/utils.py
+++ b/mslib/_tests/utils.py
@@ -183,6 +183,10 @@ def mscolab_start_server(all_ports, mscolab_settings=mscolab_settings):
     _app.config['URL'] = url
 
     _app, sockio, cm, fm = initialize_managers(_app)
+
+    # ToDo refactoring for spawn needed, fork is not implemented on windows, spawn is default on MAC and Windows
+    if multiprocessing.get_start_method(allow_none=True) != 'fork':
+        multiprocessing.set_start_method("fork")
     process = multiprocessing.Process(
         target=start_server,
         args=(_app, sockio, cm, fm,),

--- a/mslib/mscolab/_tests/test_chat.py
+++ b/mslib/mscolab/_tests/test_chat.py
@@ -24,6 +24,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
 import datetime
 import json
 import sys
@@ -31,6 +32,7 @@ import time
 import fs
 import requests
 import socketio
+import pytest
 
 from PyQt5 import QtWidgets
 from werkzeug.urls import url_join
@@ -44,6 +46,8 @@ from mslib._tests.utils import mscolab_start_server
 PORTS = list(range(9300, 9320))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_Chat(object):
     def setup(self):
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)

--- a/mslib/mscolab/_tests/test_chat_manager.py
+++ b/mslib/mscolab/_tests/test_chat_manager.py
@@ -23,10 +23,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
 import requests
 import json
 import sys
 import time
+import pytest
 
 from werkzeug.urls import url_join
 from PyQt5 import QtWidgets
@@ -40,6 +42,8 @@ from mslib._tests.utils import mscolab_start_server
 PORTS = list(range(9321, 9340))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_Chat_Manager(object):
     def setup(self):
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)

--- a/mslib/mscolab/_tests/test_file_manager.py
+++ b/mslib/mscolab/_tests/test_file_manager.py
@@ -23,6 +23,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
 import requests
 import json
 import sys
@@ -39,6 +40,8 @@ from mslib._tests.utils import mscolab_start_server
 PORTS = list(range(19341, 19390))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_FileManager(object):
     def setup(self):
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)

--- a/mslib/mscolab/_tests/test_files.py
+++ b/mslib/mscolab/_tests/test_files.py
@@ -47,6 +47,8 @@ from mslib.msui.mscolab import MSSMscolabWindow
 PORTS = list(range(9361, 9380))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_Files(object):
     def setup(self):
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)

--- a/mslib/mscolab/_tests/test_files_api.py
+++ b/mslib/mscolab/_tests/test_files_api.py
@@ -24,6 +24,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
+import pytest
 import requests
 import json
 import sys
@@ -42,6 +44,8 @@ from mslib.msui.mscolab import MSSMscolabWindow
 PORTS = list(range(9381, 9400))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_Files(object):
     def setup(self):
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)

--- a/mslib/mscolab/_tests/test_server.py
+++ b/mslib/mscolab/_tests/test_server.py
@@ -23,9 +23,11 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
 import io
 import time
 import sys
+import pytest
 from pathlib import Path
 from flask import json
 from werkzeug.urls import url_join
@@ -42,6 +44,8 @@ from PyQt5 import QtWidgets
 PORTS = list(range(10481, 10530))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_Init_Server(object):
     def setup(self):
         self.process, self.url, self.app, self.sockio, self.cm, self.fm = mscolab_start_server(PORTS)
@@ -69,6 +73,8 @@ class Test_Init_Server(object):
         assert 'Class with handler functions for file related functionalities' in self.fm.__doc__
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_Server(object):
     def setup(self):
         mscolab_settings.enable_basic_http_authentication = False

--- a/mslib/mscolab/_tests/test_sockets.py
+++ b/mslib/mscolab/_tests/test_sockets.py
@@ -24,12 +24,14 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
 import socketio
 from functools import partial
 import requests
 import json
 import sys
 import time
+import pytest
 
 from PyQt5 import QtWidgets
 from mslib.mscolab.conf import mscolab_settings
@@ -40,6 +42,8 @@ from mslib._tests.utils import mscolab_start_server
 PORTS = list(range(9521, 9540))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_Sockets(object):
     chat_messages_counter = [0, 0, 0]  # three sockets connected a, b, and c
     chat_messages_counter_a = 0  # only for first test

--- a/mslib/mscolab/_tests/test_user.py
+++ b/mslib/mscolab/_tests/test_user.py
@@ -23,6 +23,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
+import pytest
 import requests
 import json
 import sys
@@ -38,6 +40,8 @@ from mslib._tests.utils import mscolab_start_server
 PORTS = list(range(9541, 9560))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_UserMethods(object):
     def setup(self):
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)

--- a/mslib/mscolab/_tests/test_utils.py
+++ b/mslib/mscolab/_tests/test_utils.py
@@ -23,8 +23,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
 import sys
 import time
+import pytest
 
 from PyQt5 import QtWidgets
 
@@ -38,6 +40,8 @@ from mslib._tests.utils import mscolab_start_server
 PORTS = list(range(9561, 9580))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_Utils(object):
     def setup(self):
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)

--- a/mslib/msui/_tests/test_editor.py
+++ b/mslib/msui/_tests/test_editor.py
@@ -27,6 +27,7 @@
 
 import mock
 import os
+import fs
 import sys
 from PyQt5 import QtWidgets
 from mslib.msui import editor
@@ -34,10 +35,11 @@ from mslib._tests.constants import ROOT_DIR
 
 
 class Test_Editor(object):
-    sample_file = os.path.join(os.path.dirname(__file__), "..", "..", "..", "docs",
-                               "samples", "config", "mss", "mss_settings.json.sample")
+    sample_file = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", "docs",
+                                  "samples", "config", "mss", "mss_settings.json.sample"))
+    sample_file = sample_file.replace('\\', '/')
 
-    save_file_name = os.path.join(ROOT_DIR, "testeditor_save.json")
+    save_file_name = fs.path.join(ROOT_DIR, "testeditor_save.json")
 
     @mock.patch("PyQt5.QtWidgets.QMessageBox.warning", return_value=QtWidgets.QMessageBox.Yes)
     def setup(self, mockmessage):

--- a/mslib/msui/_tests/test_kmloverlay_dockwidget.py
+++ b/mslib/msui/_tests/test_kmloverlay_dockwidget.py
@@ -33,7 +33,7 @@ from PyQt5 import QtWidgets, QtCore, QtTest, QtGui
 from mslib._tests.constants import ROOT_DIR
 import mslib.msui.kmloverlay_dockwidget as kd
 
-sample_path = fs.path.join(os.path.dirname(__file__), "..", "..", "..", "docs", "samples")
+sample_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "docs", "samples")
 save_kml = os.path.join(ROOT_DIR, "merged_file123.kml")
 
 

--- a/mslib/msui/_tests/test_mscolab.py
+++ b/mslib/msui/_tests/test_mscolab.py
@@ -42,6 +42,8 @@ from mslib._tests.utils import mscolab_start_server
 PORTS = list(range(9481, 9530))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_Mscolab(object):
     sample_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "docs", "samples", "flight-tracks")
 

--- a/mslib/msui/_tests/test_mscolab_admin_window.py
+++ b/mslib/msui/_tests/test_mscolab_admin_window.py
@@ -24,6 +24,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
+import pytest
 import sys
 import time
 
@@ -36,6 +38,8 @@ from mslib._tests.utils import mscolab_start_server
 PORTS = list(range(9531, 9550))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_MscolabAdminWindow(object):
     def setup(self):
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)

--- a/mslib/msui/_tests/test_mscolab_merge_waypoints.py
+++ b/mslib/msui/_tests/test_mscolab_merge_waypoints.py
@@ -24,6 +24,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
 import sys
 import time
 
@@ -40,6 +41,8 @@ from mslib._tests.utils import mscolab_start_server
 PORTS = list(range(9551, 9570))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 @pytest.mark.skip('these tests run on direct call')
 class Test_Mscolab(object):
     def setup(self):

--- a/mslib/msui/_tests/test_mscolab_project.py
+++ b/mslib/msui/_tests/test_mscolab_project.py
@@ -24,8 +24,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
 import sys
 import time
+import pytest
 
 from mslib.msui.mscolab import MSSMscolabWindow
 from mslib.mscolab.conf import mscolab_settings
@@ -45,6 +47,8 @@ class Actions(object):
     DELETE = 4
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_MscolabProject(object):
     def setup(self):
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)

--- a/mslib/msui/_tests/test_mscolab_version_history.py
+++ b/mslib/msui/_tests/test_mscolab_version_history.py
@@ -24,6 +24,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 """
+import os
 import sys
 import time
 import pytest
@@ -38,6 +39,8 @@ from PyQt5 import QtCore, QtTest, QtWidgets
 PORTS = list(range(9591, 9620))
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_MscolabVersionHistory(object):
     def setup(self):
         self.process, self.url, self.app, _, self.cm, self.fm = mscolab_start_server(PORTS)

--- a/mslib/msui/_tests/test_mss_pyui.py
+++ b/mslib/msui/_tests/test_mss_pyui.py
@@ -40,6 +40,7 @@ class Test_MSSSideViewWindow(object):
     sample_path = os.path.join(os.path.dirname(__file__), "..", "..", "..", "docs", "samples", "flight-tracks")
     save_csv = os.path.join(ROOT_DIR, "example.csv")
     save_ftml = os.path.join(ROOT_DIR, "example.ftml")
+    save_ftml = save_ftml.replace('\\', '/')
     save_txt = os.path.join(ROOT_DIR, "example.txt")
 
     def setup(self):

--- a/mslib/msui/_tests/test_sideview.py
+++ b/mslib/msui/_tests/test_sideview.py
@@ -27,6 +27,7 @@
 
 import mock
 import os
+import pytest
 import shutil
 import sys
 import multiprocessing
@@ -126,6 +127,8 @@ class Test_MSSSideViewWindow(object):
         QtWidgets.QApplication.processEvents()
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_SideViewWMS(object):
     def setup(self):
         self.application = QtWidgets.QApplication(sys.argv)

--- a/mslib/msui/_tests/test_topview.py
+++ b/mslib/msui/_tests/test_topview.py
@@ -29,6 +29,7 @@ from __future__ import division
 
 import mock
 import os
+import pytest
 import shutil
 import sys
 import multiprocessing
@@ -256,6 +257,8 @@ class Test_MSSTopViewWindow(object):
         assert mockbox.critical.call_count == 0
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_TopViewWMS(object):
     def setup(self):
         self.port = PORTS.pop()

--- a/mslib/msui/_tests/test_wms_control.py
+++ b/mslib/msui/_tests/test_wms_control.py
@@ -104,6 +104,8 @@ class WMSControlWidgetSetup(object):
         QtTest.QTest.qWait(5000)  # time for the server to parse all netcdf data
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
     def setup(self):
         self._setup("hsec")
@@ -254,6 +256,8 @@ class Test_HSecWMSControlWidget(WMSControlWidgetSetup):
         assert self.view.draw_metadata.call_count == 1
 
 
+@pytest.mark.skipif(os.name == "nt",
+                    reason="multiprocessing needs currently start_method fork")
 class Test_VSecWMSControlWidget(WMSControlWidgetSetup):
     def setup(self):
         self._setup("vsec")


### PR DESCRIPTION
* use fs.join_path and url_join

* path for windows unified to slash

* we need on windows os.path.join for relative pathes to sample files

* forced multiprocessing start_method fork, disabled tests for windows

we need to refactor mss to be able to use spawn method for windows and
MacOSX

* skip test for windows because of multiprocessing start_method fork

* skip test for windows because of multiprocessing start_method fork

* flake8 fix

* test_editor fixed path issues for windows

* flake8 fix

* solved save_ftml file path issues for windows